### PR TITLE
Fix timestamp note hover jitter and prevent layout shift

### DIFF
--- a/src/contentScript/contentScript.css
+++ b/src/contentScript/contentScript.css
@@ -44,6 +44,14 @@
   box-shadow: 0 4px 0.25rem rgba(0, 0, 0, 0.1);
   z-index: 100;
   pointer-events: none;
+
+  width: 300px;
+  height: 32px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-sizing: border-box;
+
   &.show {
     display: block;
   }

--- a/src/contentScript/contentScript.tsx
+++ b/src/contentScript/contentScript.tsx
@@ -331,7 +331,7 @@ async function loadTimestamps() {
         bookmarkDescription.classList.remove("show");
       });
     }
-  }, 16); // ~60fps throttle
+  }, 100); // 100ms throttle to reduce jitter
   
   progressBar.addEventListener("mousemove", handleMouseMove);
 }


### PR DESCRIPTION
Reduced jitter when hovering over video timestamps by increasing the throttle limit and fixing the dimensions of the notes box. Added text overflow handling with ellipsis to prevent content from spilling out of the fixed-size box.

Fixes #4

---
*PR created automatically by Jules for task [10031329606542114604](https://jules.google.com/task/10031329606542114604) started by @aadilmallick*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bookmark hover descriptions so long text stays within a fixed width and truncates cleanly instead of overflowing.
  * Smoothed hover behavior by reducing how often description updates fire during mouse movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->