### PR TITLE
Add Create Release GitHub Action

### DIFF
--- a/.github/workflows/build-zip.yaml
+++ b/.github/workflows/build-zip.yaml
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Zip extension
-        run: zip -r chrome-extension.zip dist/
+        run: cd dist && zip -r ../chrome-extension.zip .
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-zip.yaml
+++ b/.github/workflows/build-zip.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   # Trigger on pull requests targeting the main branch
   pull_request:
     branches:
@@ -16,6 +18,8 @@ on:
 jobs:
   build-on-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -29,17 +33,20 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Zip extension
+        run: zip -r chrome-extension.zip dist/
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: chrome-extension
-          path: dist/ # Ensure this matches your build output folder
+          path: chrome-extension.zip
 
       # Fix 2: Add a release or publish step
       - name: Create Release
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: dist/**
+          files: chrome-extension.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Modified the `.github/workflows/build-zip.yaml` file to automate GitHub Release creation.

Key changes:
1. Updated `on.push.tags` to trigger on `v*` tags.
2. Added `permissions: contents: write` to the job for release permissions.
3. Introduced a "Zip extension" step using the `zip` utility.
4. Updated "Upload Artifact" to use the new `chrome-extension.zip`.
5. Updated "Create Release" to upload `chrome-extension.zip` when triggered by a tag.

Fixes #6

---
*PR created automatically by Jules for task [12027418728040919896](https://jules.google.com/task/12027418728040919896) started by @aadilmallick*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release builds now run and publish from version tags matching `v*`, in addition to the main branch.
  * Release downloads include a packaged ZIP file for installation.

* **Bug Fixes**
  * Updated the build/release artifact process to package `dist/` into a ZIP first, then publish that ZIP consistently as the release asset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->